### PR TITLE
updating readme to support wget installation as well as curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,21 @@
 
 ### Dependencies
 
-- curl
+- curl or wget
 - fontconfig
 
 ### Installation
 
+using curl:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/getnf/getnf/main/install.sh)
 ```
-curl -fsSL https://raw.githubusercontent.com/getnf/getnf/main/install.sh | bash
+
+or using wget:
+
+```bash
+bash <(wget -qO- https://raw.githubusercontent.com/getnf/getnf/main/install.sh)
 ```
 
 Make sure that `~/.local/bin` is in your PATH.


### PR DESCRIPTION
Pretty much what the title says, I have tested this across 3 devices.

I made this change primarily because I primarily use wget because it's easier